### PR TITLE
feat: add RN cookie

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -329,6 +329,8 @@ PODS:
   - React-jsinspector (0.71.8)
   - React-logger (0.71.8):
     - glog
+  - react-native-cookies (6.2.1):
+    - React-Core
   - react-native-webview (12.1.0):
     - React-Core
   - React-perflogger (0.71.8)
@@ -466,6 +468,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - "react-native-cookies (from `../node_modules/@react-native-cookies/cookies`)"
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -541,6 +544,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-cookies:
+    :path: "../node_modules/@react-native-cookies/cookies"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
   React-perflogger:
@@ -606,6 +611,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 747911ab5921641b4ed7e4900065896597142125
   React-jsinspector: c712f9e3bb9ba4122d6b82b4f906448b8a281580
   React-logger: 342f358b8decfbf8f272367f4eacf4b6154061be
+  react-native-cookies: f54fcded06bb0cda05c11d86788020b43528a26c
   react-native-webview: 13db17f7c7fe8f91c826e9afcc369cbc74507ea0
   React-perflogger: d21f182895de9d1b077f8a3cd00011095c8c9100
   React-RCTActionSheet: 0151f83ef92d2a7139bba7dfdbc8066632a6d47b

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@react-native-cookies/cookies": "^6.2.1",
     "react": "18.2.0",
     "react-native": "0.71.8",
     "react-native-webview": "^12.1.0"
@@ -23,20 +24,20 @@
     "@types/jest": "^29.2.1",
     "@types/react": "^18.0.24",
     "@types/react-test-renderer": "^18.0.0",
+    "@typescript-eslint/parser": "^5.59.8",
     "babel-jest": "^29.2.1",
     "eslint": "^8.19.0",
-    "jest": "^29.2.1",
-    "metro-react-native-babel-preset": "0.73.9",
-    "prettier": "^2.4.1",
-    "react-test-renderer": "18.2.0",
-    "typescript": "4.8.4",
-    "@typescript-eslint/parser": "^5.59.8",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "lint-staged": "^13.2.2"
+    "jest": "^29.2.1",
+    "lint-staged": "^13.2.2",
+    "metro-react-native-babel-preset": "0.73.9",
+    "prettier": "^2.4.1",
+    "react-test-renderer": "18.2.0",
+    "typescript": "4.8.4"
   },
   "jest": {
     "preset": "react-native"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,6 +1732,13 @@
   resolved "https://registry.npmjs.org/@react-native-community/eslint-plugin/-/eslint-plugin-1.3.0.tgz"
   integrity sha512-+zDZ20NUnSWghj7Ku5aFphMzuM9JulqCW+aPXT6IfIXFbb8tzYTTOSeRFOtuekJ99ibW2fUCSsjuKNlwDIbHFg==
 
+"@react-native-cookies/cookies@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-cookies/cookies/-/cookies-6.2.1.tgz#54d50b9496400bbdc19e43c155f70f8f918999e3"
+  integrity sha512-D17wCA0DXJkGJIxkL74Qs9sZ3sA+c+kCoGmXVknW7bVw/W+Vv1m/7mWTNi9DLBZSRddhzYw8SU0aJapIaM/g5w==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@react-native/assets/-/assets-1.0.0.tgz"


### PR DESCRIPTION
### ⛳️ Task
- cookie를 설정해주는 패키지 [react-native-cookies](https://www.npmjs.com/package/@react-native-cookies/cookies)를 설치했습니다.
  - RN에 쿠키를 설정, 저장할수 있고 서드파티(웹뷰 등)와 쿠키를 공유할수 있게 해주는 라이브러리 입니다.
  - 인증 관련 쿠키는 우선 웹에서만 쿠키를 보관해보고, 앱에는 추후 필요시 저장하려고 합니다.

### ✍️ Note

### ⚡️ Test
해당 pr은 쿠키만 설정해줍니다. 아래의 테스트는 꼭 수행해보시지 않으셔도 무방하며 참고용으로 공유드립니다.
1. `/constants/common.ts`의 BASE_URI를 localhost:3000로 변경합니다.
2. 웹뷰에서는 url에 직접 접근하기 어렵기 때문에 로컬에서 next 웹 서버를 구동후 홈 화면에 로그인 페이지로 이동하는 버튼을 테스트용으로 추가해줍니다.
  ```
<a href="/auth/signin">로그인</a>
```
<img width="224" alt="스크린샷 2023-06-12 오전 1 21 47" src="https://github.com/depromeet/Ding-dong-app/assets/61297852/f35c290b-c707-42b8-a48d-1366dc131ba6">

3. 이 [pr](https://github.com/depromeet/Ding-dong-fe/pull/38)이 머지되면 웹뷰에서 로그인 해볼수 있습니다.
<img width="233" alt="스크린샷 2023-06-12 오전 1 23 21" src="https://github.com/depromeet/Ding-dong-app/assets/61297852/82c1c0ea-6895-4591-af2d-70af9e7d37b6">

<img width="235" alt="스크린샷 2023-06-11 오후 11 51 57" src="https://github.com/depromeet/Ding-dong-app/assets/61297852/61108d2a-a637-4ea4-a3e3-ac36b92a5c94">

![스크린샷 2023-06-11 오후 11 52 48](https://github.com/depromeet/Ding-dong-app/assets/61297852/7c0269ad-2704-4e3c-a8d0-9c7e6c81c535)
(웹 middleware.ts  25번째 라인에 다음 콘솔을 입력하면 next 터미널에서 인증 결과를 확인할 수 있습니다 )
```
    console.log(data, success);
```


### 📸 Screenshot
| AS-IS | TO-BE |
|-----|-----|
|||

### 📎 Reference